### PR TITLE
Return tokens if ngram size is 1

### DIFF
--- a/src/Analysis/Keywords/Rake.php
+++ b/src/Analysis/Keywords/Rake.php
@@ -67,6 +67,9 @@ class Rake
      */
     public function getPhrases()
     {   
+        if($this->nGramSize==1)
+                return $this->getTokens();
+
         $phrases = [];
 
         for($index = $this->nGramSize; $index >= 2; $index--)


### PR DESCRIPTION
I think this makes sense.  Otherwise, getPhrases() returns empty array, which seems wrong.