### PR TITLE
Declare helper function only if it does not already exist

### DIFF
--- a/src/helpers/helpers.php
+++ b/src/helpers/helpers.php
@@ -5,90 +5,109 @@
  * make it easier to access core functionality
  */
 
-
-/**
- * Normalize the tokens
- * @param array $tokens
- * @param string|function $normalizer
- * @return array
- */
-function normalize_tokens(array $tokens, $normalizer = 'strtolower') : array
-{
-    return array_map($normalizer, $tokens);
+if (! function_exists('normalize_tokens')) {
+	/**
+	 * Normalize the tokens
+	 *
+	 * @param array $tokens
+	 * @param string|function $normalizer
+	 *
+	 * @return array
+	 */
+	function normalize_tokens( array $tokens, $normalizer = 'strtolower' ): array {
+		return array_map( $normalizer, $tokens );
+	}
 }
 
-/**
- * Tokenize text into an array of tokens
- * @param string $text
- * @param string $tokenizerClassName
- * @return array
- */
-function tokenize(string $text, string $tokenizerClassName = \TextAnalysis\Tokenizers\GeneralTokenizer::class) : array
-{
-    return (new $tokenizerClassName())->tokenize($text);
+if (! function_exists('tokenize')) {
+	/**
+	 * Tokenize text into an array of tokens
+	 *
+	 * @param string $text
+	 * @param string $tokenizerClassName
+	 *
+	 * @return array
+	 */
+	function tokenize( string $text, string $tokenizerClassName = \TextAnalysis\Tokenizers\GeneralTokenizer::class ): array {
+		return ( new $tokenizerClassName() )->tokenize( $text );
+	}
 }
 
-/**
- * Shortcut for getting a freq distribution instance 
- * @param array $tokens
- * @return \TextAnalysis\Analysis\FreqDist
- */
-function freq_dist(array $tokens) : \TextAnalysis\Analysis\FreqDist
-{
-    return new \TextAnalysis\Analysis\FreqDist($tokens);
+if (! function_exists('freq_dist')) {
+	/**
+	 * Shortcut for getting a freq distribution instance
+	 *
+	 * @param array $tokens
+	 *
+	 * @return \TextAnalysis\Analysis\FreqDist
+	 */
+	function freq_dist( array $tokens ): \TextAnalysis\Analysis\FreqDist {
+		return new \TextAnalysis\Analysis\FreqDist( $tokens );
+	}
 }
 
-/**
- * 
- * @param array $tokens
- * @param type $lexicalDiversityClassName
- * @return float
- */
-function lexical_diversity(array $tokens, $lexicalDiversityClassName = \TextAnalysis\LexicalDiversity\Naive::class) : float
-{
-    return (new $lexicalDiversityClassName())->getDiversity($tokens);
+if (! function_exists('lexical_diversity')) {
+	/**
+	 *
+	 * @param array $tokens
+	 * @param type $lexicalDiversityClassName
+	 *
+	 * @return float
+	 */
+	function lexical_diversity( array $tokens, $lexicalDiversityClassName = \TextAnalysis\LexicalDiversity\Naive::class ): float {
+		return ( new $lexicalDiversityClassName() )->getDiversity( $tokens );
+	}
 }
 
-/**
- * 
- * @param array $tokens
- * @param type $nGramSize
- * @param type $separator
- * @return array
- */
-function ngrams(array $tokens, $nGramSize = 2, $separator = ' ') : array
-{
-    return \TextAnalysis\NGrams\NGramFactory::create($tokens, $nGramSize, $separator);
+if (! function_exists('ngrams')) {
+	/**
+	 *
+	 * @param array $tokens
+	 * @param type $nGramSize
+	 * @param type $separator
+	 *
+	 * @return array
+	 */
+	function ngrams( array $tokens, $nGramSize = 2, $separator = ' ' ): array {
+		return \TextAnalysis\NGrams\NGramFactory::create( $tokens, $nGramSize, $separator );
+	}
 }
 
-/**
- * 
- * @param string $haystack
- * @param string $needle
- * @return bool
- */
-function starts_with(string $haystack, string $needle) : bool
-{
-    return \TextAnalysis\Utilities\Text::startsWith($haystack, $needle);
+if (! function_exists('starts_with')) {
+	/**
+	 *
+	 * @param string $haystack
+	 * @param string $needle
+	 *
+	 * @return bool
+	 */
+	function starts_with( string $haystack, string $needle ): bool {
+		return \TextAnalysis\Utilities\Text::startsWith( $haystack, $needle );
+	}
 }
 
-/**
- * @param string $haystack
- * @param string $needle
- * @return bool
- */
-function ends_with(string $haystack, string $needle) : bool
-{
-    return \TextAnalysis\Utilities\Text::endsWith($haystack, $needle);
+if (! function_exists('ends_with')) {
+	/**
+	 * @param string $haystack
+	 * @param string $needle
+	 *
+	 * @return bool
+	 */
+	function ends_with( string $haystack, string $needle ): bool {
+		return \TextAnalysis\Utilities\Text::endsWith( $haystack, $needle );
+	}
 }
 
-/**
- * Returns an instance of the TextCorpus
- * @param string $text
- * @return \TextAnalysis\Corpus\TextCorpus
- */
-function text(string $text) : \TextAnalysis\Corpus\TextCorpus
-{
-    return new \TextAnalysis\Corpus\TextCorpus($text);
+if (! function_exists('text')) {
+	/**
+	 * Returns an instance of the TextCorpus
+	 *
+	 * @param string $text
+	 *
+	 * @return \TextAnalysis\Corpus\TextCorpus
+	 */
+	function text( string $text ): \TextAnalysis\Corpus\TextCorpus {
+		return new \TextAnalysis\Corpus\TextCorpus( $text );
+	}
 }
 

--- a/src/helpers/print.php
+++ b/src/helpers/print.php
@@ -4,16 +4,18 @@
  * Some print functions to make things easier to read
  */
 
-/**
- * Print out the strings in the array
- * @param array $strings
- * @param string $prefix
- * @param string $newline
- */
-function print_array(array $strings, $prefix = '* ', $newline = PHP_EOL)
-{
-    array_walk($strings, function($string) use ($newline, $prefix){
-        echo $prefix.$string.$newline;        
-    });
+if (! function_exists('print_array')) {
+	/**
+	 * Print out the strings in the array
+	 *
+	 * @param array $strings
+	 * @param string $prefix
+	 * @param string $newline
+	 */
+	function print_array( array $strings, $prefix = '* ', $newline = PHP_EOL ) {
+		array_walk( $strings, function ( $string ) use ( $newline, $prefix ) {
+			echo $prefix . $string . $newline;
+		} );
+	}
 }
 

--- a/src/helpers/simplified.php
+++ b/src/helpers/simplified.php
@@ -4,25 +4,29 @@
  * Short cut functions calls
  */
 
-/**
- * 
- * @param array $tokens
- * @param string $separator
- * @return array
- */
-function bigrams(array $tokens, $separator = ' ')
-{
-    return \TextAnalysis\NGrams\NGramFactory::create($tokens, 2, $separator);
+if (! function_exists('bigrams')) {
+	/**
+	 *
+	 * @param array $tokens
+	 * @param string $separator
+	 *
+	 * @return array
+	 */
+	function bigrams( array $tokens, $separator = ' ' ) {
+		return \TextAnalysis\NGrams\NGramFactory::create( $tokens, 2, $separator );
+	}
 }
 
-/**
- * 
- * @param array $tokens
- * @param string $separator
- * @return array
- */
-function trigrams(array $tokens, $separator = ' ')
-{
-    return \TextAnalysis\NGrams\NGramFactory::create($tokens, 3, $separator);
+if (! function_exists('trigrams')) {
+	/**
+	 *
+	 * @param array $tokens
+	 * @param string $separator
+	 *
+	 * @return array
+	 */
+	function trigrams( array $tokens, $separator = ' ' ) {
+		return \TextAnalysis\NGrams\NGramFactory::create( $tokens, 3, $separator );
+	}
 }
 

--- a/src/helpers/storage.php
+++ b/src/helpers/storage.php
@@ -1,22 +1,23 @@
 <?php
 
-/**
- * Base function for getting the storage path to the different directories.
- * @return string
- */
-function get_storage_path($subDirName = null)
-{
-    $path = dirname(dirname(__DIR__)).DIRECTORY_SEPARATOR.'storage'.DIRECTORY_SEPARATOR;
-    
-    if(!empty($path)) { 
-        $path .= $subDirName;
-    }
-    
-    if(!is_dir($path)) {
-        throw new Exception("Path {$path} does not exist");
-    }
-    
-    return realpath($path).DIRECTORY_SEPARATOR;
-    
+if (! function_exists('get_storage_path')) {
+	/**
+	 * Base function for getting the storage path to the different directories.
+	 * @return string
+	 */
+	function get_storage_path( $subDirName = null ) {
+		$path = dirname( dirname( __DIR__ ) ) . DIRECTORY_SEPARATOR . 'storage' . DIRECTORY_SEPARATOR;
+
+		if ( ! empty( $path ) ) {
+			$path .= $subDirName;
+		}
+
+		if ( ! is_dir( $path ) ) {
+			throw new Exception( "Path {$path} does not exist" );
+		}
+
+		return realpath( $path ) . DIRECTORY_SEPARATOR;
+
+	}
 }
 


### PR DESCRIPTION
Hi, 
thank you for your work on 'php-text-analysis'. 
I've tried to use it in Laravel 5.5 PHP framework application, but couldn't because Laravel already has two helper functions declared with the same name as in 'php-text-analysis' helper functions. Those are: 'starts_with()' and 'ends_with()'. 
I suggest that you make helper function declaration happen only if the function with the same name doesn't already exist, if that's OK in your case.
Greetings from Zagreb, Croatia
Marko

![image](https://user-images.githubusercontent.com/3176844/34722295-8db27642-f546-11e7-997a-d26e758c0b50.png)
