### PR TITLE
Improved concordance method

### DIFF
--- a/src/Corpus/TextCorpus.php
+++ b/src/Corpus/TextCorpus.php
@@ -150,23 +150,6 @@ class TextCorpus
     }
 
     /**
-    * Mark the neddle and get its context
-    *
-    * @return String
-    */
-    private function extractExcerptTerm(int $needlePos, int $needleLength, String $text, int $contextLength, bool $mark = false)
-    {
-        //marking the term
-        $text = ($mark) ? Text::markString($text, $needlePos, $needleLength, ['{{','}}']) : $text;
-        $needleLength = ($mark) ? $needleLength+4 : $needleLength;
-
-        //extracts the excerpt
-        $text = Text::getExcerpt($text, $needlePos, $needleLength, $contextLength);
-
-        return utf8_encode($text);
-    }
-
-    /**
      * Get percentage of times the needle shows up in the text
      * @param string $needle
      * @return float

--- a/src/Corpus/TextCorpus.php
+++ b/src/Corpus/TextCorpus.php
@@ -137,11 +137,11 @@ class TextCorpus
     public function occurrences(string $needle, int $contextLength = 20, bool $ignorecase = true, string $position = 'contain', bool $mark = false) : array
     {
         // temporary solution to handle unicode chars
-        $this->text = utf8_decode($this->text);
+        $text = utf8_decode($this->text);
         $needle = utf8_decode($needle);
 
         $found = [];
-        $text = trim(preg_replace('/[\s\t\n\r\s]+/', ' ', $this->text));
+        $text = trim(preg_replace('/[\s\t\n\r\s]+/', ' ', $text));
         $needleLength = strlen($needle);
         $textLength = strlen($text);
         $bufferLength = $needleLength + 2 * $contextLength;

--- a/src/Corpus/TextCorpus.php
+++ b/src/Corpus/TextCorpus.php
@@ -141,7 +141,7 @@ class TextCorpus
         $needle = utf8_decode($needle);
 
         $found = [];
-        $text = ' ' . trim(preg_replace('/[\s\t\n\r\s]+/', ' ', $this->text)) . ' ';
+        $text = trim(preg_replace('/[\s\t\n\r\s]+/', ' ', $this->text));
         $needleLength = strlen($needle);
         $textLength = strlen($text);
         $bufferLength = $needleLength + 2 * $contextLength;
@@ -153,13 +153,13 @@ class TextCorpus
 
         switch ($position) {
             case 'equal':
-                $pattern = "/[^$word_part]($needle)[^$word_part]/";
+                $pattern = "/(?<![$word_part])($needle)(?![$word_part])/";
                 break;
             case 'begin':
-                $pattern = "/[^$word_part]($needle)[$special_chars]?[\p{L}]*|^($needle)/";
+                $pattern = "/(?<![$word_part])($needle)[$special_chars]?[\p{L}]*|^($needle)/";
                 break;
             case 'end':
-                $pattern = "/[\p{L}]*[$special_chars]?[\p{L}]*($needle)[^$word_part]/";
+                $pattern = "/[\p{L}]*[$special_chars]?[\p{L}]*($needle)(?![$word_part])/";
                 break;
             case 'contain':
                 $pattern = "/($needle)/";
@@ -171,7 +171,6 @@ class TextCorpus
 
         $case = $ignorecase ? 'i' : '';
         preg_match_all($pattern.$case, $text, $matches, PREG_OFFSET_CAPTURE);
-
         $positions = array_column($matches[1], 1);
 
         $excerpts = array_map(function($needlePos) use ($needleLength, $text, $contextLength, $mark) {

--- a/src/Utilities/Text.php
+++ b/src/Utilities/Text.php
@@ -5,15 +5,15 @@ namespace TextAnalysis\Utilities;
  * Additional string functions
  * @author yooper (yooper)
  */
-class Text 
+class Text
 {
     protected function __construct(){}
-    
+
     /**
      * http://stackoverflow.com/questions/834303/php-startswith-and-endswith-functions
      * @param string $haystack
      * @param string $needle
-     * @return boolean 
+     * @return boolean
      */
     static public function startsWith($haystack, $needle)
     {
@@ -23,19 +23,19 @@ class Text
     /**
      * @param string $haystack
      * @param string $needle
-     * @return boolean 
+     * @return boolean
      */
     static public function endsWith($haystack, $needle)
     {
         return strpos($haystack, $needle) === (strlen($haystack) - strlen($needle));
     }
-    
+
     static public function contains($haystack, $needle)
     {
         return (strpos($haystack, $needle) !== false);
     }
-    
-    
+
+
     /**
      * Takes a string and produces all possible substrings
      * @param string $text
@@ -45,17 +45,17 @@ class Text
     {
         $splitText = str_split($text);
         $splitCount = count($splitText);
-        $subStrings = [];        
-        for ($i = 0; $i < $splitCount; $i++) 
+        $subStrings = [];
+        for ($i = 0; $i < $splitCount; $i++)
         {
-            for ($j = $i; $j < $splitCount; $j++) 
+            for ($j = $i; $j < $splitCount; $j++)
             {
                 $subStrings[] = implode(array_slice($splitText, $i, $j - $i + 1));
-            }       
+            }
         }
-        return $subStrings;        
+        return $subStrings;
     }
-    
+
     /**
      * Find Date in a String
      *
@@ -215,5 +215,37 @@ class Text
       else
         return $date;
     }
-  
+
+    /**
+    * Mark a string
+    *
+    * @return String
+    */
+    static function markString(String $text, int $position, int $length, Array $mark)
+    {
+        $text = substr_replace($text, $mark[0], $position, 0);
+        $text = substr_replace($text, $mark[1], $position + $length + strlen($mark[0]), 0);
+
+        return $text;
+    }
+
+    /**
+    * Get a excerpt from a string by a neddle postion and its length
+    *
+    * @return String
+    */
+    static function getExcerpt(String $text, int $needlePosition, int $needleLength, int $contextLength)
+    {
+        $left = max($needlePosition - $contextLength, 0);
+        $bufferLength = $needleLength + (2 * $contextLength);
+
+        if($needleLength + $contextLength + $needlePosition > strlen($text)) {
+            $text = substr($text, $left);
+        } else {
+            $text = substr($text, $left, $bufferLength);
+        }
+
+        return $text;
+    }
+
 }

--- a/src/Utilities/Text.php
+++ b/src/Utilities/Text.php
@@ -219,9 +219,13 @@ class Text
     /**
     * Mark a string
     *
-    * @return String
+    * @param string $text
+    * @param int $position
+    * @param int $length
+    * @param array $mark
+    * @return string
     */
-    static function markString(String $text, int $position, int $length, Array $mark)
+    static function markString(string $text, int $position, int $length, array $mark) : string
     {
         $text = substr_replace($text, $mark[0], $position, 0);
         $text = substr_replace($text, $mark[1], $position + $length + strlen($mark[0]), 0);
@@ -232,9 +236,13 @@ class Text
     /**
     * Get a excerpt from a string by a neddle postion and its length
     *
-    * @return String
+    * @param string $text
+    * @param int $needlePosition
+    * @param int $needleLength
+    * @param int $contextLength
+    * @return string
     */
-    static function getExcerpt(String $text, int $needlePosition, int $needleLength, int $contextLength)
+    static function getExcerpt(String $text, int $needlePosition, int $needleLength, int $contextLength) : string
     {
         $left = max($needlePosition - $contextLength, 0);
         $bufferLength = $needleLength + (2 * $contextLength);


### PR DESCRIPTION
Hello, @yooper !
@thiagogomesverissimo and I worked some things on the concordance method.

- We uncoupled concordance function. We created: a method that only returns the positions of the needle in the text; a method that marks a needle in a string and a method that returns an excerpt from a string.
- Improved the regex used to find the needle. Changed negated set to negative lookahead and lookbehind. This way it will capture correctly groups at the beginning of the string and at the
end of the string without the need to add spaces.
- And fixed the text variable so it won't convert a string with ISO-8859-1 if the method

If you have any questions or suggestions, feel free to ask me or @thiagogomesverissimo .
Thank you.