### PR TITLE
Fixed polarity bug getting 'Undefined offset: 1' along with normalization bug getting Divison by zero error.

### DIFF
--- a/src/Sentiment/Vader.php
+++ b/src/Sentiment/Vader.php
@@ -126,7 +126,12 @@ class Vader
      */
     public function normalize(float $score, int $alpha=15)
     {
-        $normalizedScore = $score/sqrt(($score^2) + $alpha);
+        $normalizedScore = $score;
+
+        if (sqrt(($score^2) + $alpha > 0)) {
+            $normalizedScore = $score/sqrt(($score^2) + $alpha);
+        }
+
         if ($normalizedScore < -1.0) {
             return -1.0;
         } elseif ($normalizedScore > 1.0) {

--- a/src/Sentiment/Vader.php
+++ b/src/Sentiment/Vader.php
@@ -176,8 +176,9 @@ class Vader
         {
             $valence = 0.0;
             $lcToken = strtolower($tokens[$index]);
-            if( $lcToken === "kind" && strtolower($tokens[$index+1]) === 'of' ||
-                isset(self::$this->boosterDict[$lcToken]) ) {   
+            if( $lcToken === "kind" 
+            && (array_key_exists($index+1, $tokens) && strtolower($tokens[$index+1]) === 'of') ||
+                isset(self::$this->boosterDict[$lcToken]) ) { 
                 
                 $sentiments[] = $valence;
             } else {

--- a/tests/TextAnalysis/Sentiment/VaderTest.php
+++ b/tests/TextAnalysis/Sentiment/VaderTest.php
@@ -128,5 +128,28 @@ class VaderTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(0.6197, $sentimentScores['compound']);
     }
+
+    public function testNormalizeZeroSum()
+    {
+        if( getenv('SKIP_TEST')) {
+            return;
+        }
+        $tokens = [
+            'If','the','Fake','News','Opposition','Party',
+            'is','pushing','with','all','their','might',
+            'the','fact','that','President','Trump',
+            '“ignored','early','warnings','about',
+            'the','threat','”','then','why','did',
+            'Media','&','Dems','viciously',
+            'criticize','me','when','I',
+            'instituted','a','Travel','Ban',
+            'on','China','They','said',
+            '“early','&','not','necessary.”','Corrupt','Media'
+        ];
+
+        $sentimentScores = vader($tokens);
+        
+        $this->assertEquals(-1, $sentimentScores['compound']);
+    }
         
 }

--- a/tests/TextAnalysis/Sentiment/VaderTest.php
+++ b/tests/TextAnalysis/Sentiment/VaderTest.php
@@ -97,7 +97,7 @@ class VaderTest extends \PHPUnit\Framework\TestCase
         $examples[] = ['sent' => "Make sure you :) or :D today!", 'neg'=> 0.0, 'neu'=> 0.294, 'pos'=> 0.706, 'compound'=> 0.8633];
         $examples[] = ['sent' => "Today SUX!", 'neg'=> 0.0, 'neg'=> 0.779, 'neu'=> 0.221, 'pos'=> 0.0, 'compound'=> -0.5461];
         $examples[] = ['sent' => "Today only kinda sux! But I'll get by, lol", 'neg'=> 0.179, 'neu'=> 0.569, 'pos'=> 0.251, 'compound'=> 0.2228];
-    
+        
         $vader = new Vader;
         
         foreach($examples as $test)
@@ -113,9 +113,20 @@ class VaderTest extends \PHPUnit\Framework\TestCase
             return;
         }
 	    
-	$vader = new Vader;
+	    $vader = new Vader;
         $result = $vader->getPolarityScores([ 'great', 'for', 'the', 'jawbone']);
         $this->assertEquals(0.577, $result['pos']);
+    }
+
+    public function testSentimentScoreKindOfCombo()
+    {
+        if( getenv('SKIP_TEST')) {
+            return;
+        }
+
+        $sentimentScores = vader(['kind']);
+
+        $this->assertEquals(0.6197, $sentimentScores['compound']);
     }
         
 }


### PR DESCRIPTION
When looking for the word 'of' after 'kind' where 'kind' is the last word in the sentence it will cause a lookup at an not existing index in the array.

Also fixing normalize divison by zero issue. The following trump tweet was tokenized in the unit test as it resolves to zero.

> If the Fake News Opposition Party is pushing, with all their might, the fact that President Trump “ignored early warnings about the threat,” then why did Media & Dems viciously criticize me when I instituted a Travel Ban on China? They said “early & not necessary.” Corrupt Media!