### PR TITLE
changed LambdaFilter/LambdaTokenizer phpdoc param from function to callable

### DIFF
--- a/src/Filters/LambdaFilter.php
+++ b/src/Filters/LambdaFilter.php
@@ -12,13 +12,13 @@ class LambdaFilter implements ITokenTransformation
 {
     /**
      *
-     * @var function
+     * @var callable
      */
     protected $lambdaFunc = null;
 
     /**
      * 
-     * @param function $lambdaFunc
+     * @param callable $lambdaFunc
      */
     public function __construct($lambdaFunc) 
     {

--- a/src/Tokenizers/LambdaTokenizer.php
+++ b/src/Tokenizers/LambdaTokenizer.php
@@ -14,13 +14,13 @@ class LambdaTokenizer extends TokenizerAbstract
     
     /**
      *
-     * @var function
+     * @var callable
      */
     protected $lambdaFunc = null;
 
     /**
      * 
-     * @param function $lambdaFunc
+     * @param callable $lambdaFunc
      */
     public function __construct($lambdaFunc) 
     {


### PR DESCRIPTION
Hello, I am using your library for some time and I think it is great!
But, every time I pass a callable in LambdaFilter, psalm and phpstorm arguing at me that I'm using an invalid argument like this:

`
ERROR: InvalidArgument - scripts/Namespace/VO/SomeVO.php:42:52 - Argument 1 of TextAnalysis\Filters\LambdaFilter::__construct expects TextAnalysis\Filters\function, pure-Closure(mixed):(null|string) provided (see https://psalm.dev/004)
            ->applyTransformation(new LambdaFilter(static function (string $word) {
                return preg_replace(self::AVAILABLE_CHARACTERS_REGEXP, '', $word);
            }));
`

Maybe it would be better to have `callable` phpdoc, because it doesn't lead to any errors? 
