### PR TITLE
fixed uninitialized string offset for `Porter::doubleConsonant($str)`

### DIFF
--- a/src/Stemmers/PorterStemmer.php
+++ b/src/Stemmers/PorterStemmer.php
@@ -437,7 +437,12 @@ class Porter
     {
         $c = self::$regex_consonant;
 
-        return preg_match("#$c[2]$#", $str, $matches) AND $matches[0][0] == $matches[0][1];
+        $result = preg_match("#$c[2]$#", $str, $matches);
+
+        $sub_0 = count($matches) > 0 ? substr($matches[0], 0) : false;
+        $sub_1 = count($matches) > 0 ? substr($matches[0], 1) : false;
+        
+        return $result AND is_string($sub_0) AND is_string($sub_1) AND $sub_0 == $sub_1;
     }
 
     /**


### PR DESCRIPTION
Thanks for the library!

The `Porter::doubleConsonant($str)` method errors out for me (php 8.1.19).

**Error**
`ErrorException: Uninitialized string offset 1` (line 440).

`$matches` is `[':']`.

An alternative would be to alter the regex?