### PR TITLE
Added support for wamania/php-stemmer ^2 and ^3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=7.4",
         "yooper/stop-words": "~1",
         "symfony/console": ">= 4.4",
-        "wamania/php-stemmer": "~1",
+        "wamania/php-stemmer": "^1.0 || ^2.0 || ^3.0",
         "yooper/nicknames": "~1"
     },
     "require-dev": {


### PR DESCRIPTION
As it looks like `warmania/php-stemmer` is only used [here](https://github.com/search?q=repo%3Ayooper%2Fphp-text-analysis%20Wamania%5CSnowball&type=code). Adding support for `v2` and `v3` shouldn't be of high impact.

Also don't see any major changes from current support `v1` vs `v3` ([diff](https://github.com/wamania/php-stemmer/compare/1.3...v3.0.1)).

Adding the support for newer versions makes the library a bit more flexible/usable :)